### PR TITLE
Fix menu entries not appearing after reloading scripts in Blender

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,11 +49,36 @@ submodule_names = (
 from bpy.props import PointerProperty
 from bpy.utils import register_class, unregister_class
 
+import importlib
+import sys
+
 registered_submodules = []
+
+# When the addon is reloaded, this module gets reloaded, however none
+# of the other modules from this addon get reloaded. As a result, they
+# don't call register_submodules (only run when the module is loaded) and
+# thus they don't end up registering everything.
+#
+# This is set before any loading starts (in register), to a set of all the
+# names of the modules loaded as of when loading starts. While doing the
+# module loading, check if a module is present in this list. If so, reload
+# it and remove it from the set (to prevent it from getting reloaded twice).
+preloaded_modules = None
+
 def register_submodules(name, submodule_names):
+    global preloaded_modules
     module = __import__(name=name, fromlist=submodule_names)
     submodules = [getattr(module, name) for name in submodule_names]
     for mod in submodules:
+
+        # Look through the modules present when register was called. If this
+        # module was already loaded, then reload it.
+        if mod.__name__ in preloaded_modules:
+            mod = importlib.reload(mod)
+
+            # Prevent the module from getting reloaded more than once
+            preloaded_modules.remove(mod.__name__)
+
         m = [(),()]
         if hasattr(mod, "classes_to_register"):
             m[0] = mod.classes_to_register
@@ -70,7 +95,10 @@ def register_submodules(name, submodule_names):
             registered_submodules.append(m)
 
 def register():
+    global preloaded_modules
+    preloaded_modules = set(sys.modules.keys())
     register_submodules(__name__, submodule_names);
+    preloaded_modules = None
 
 def unregister():
     for mod in reversed(registered_submodules):


### PR DESCRIPTION
Hello,

On the current HEAD, if you try to reload scripts from inside Blender (search->Reload Scripts), only the `io_object_mu` module gets reloaded, `register_submodules` only gets called once, and most stuff doesn't get registered.

(while I haven't tested it, the same problem likely also occurs when disabling and reenabling the addon in Blender's preferences)

This PR reloads all the addon's modules during a reload, which solves the problem.