### PR TITLE
fix for duplication of mesh colliders

### DIFF
--- a/collider/operators.py
+++ b/collider/operators.py
@@ -130,8 +130,12 @@ def add_mesh_colliders(self, context, convex):
             mesh = bpy.data.meshes.new_from_object(objeval)
         col = bpy.data.objects.new(name, mesh)
         context.scene.collection.objects.link(col)
+        original_collection = col.users_collection
+        if original_collection != obj.users_collection:
+            bpy.data.collections[obj.users_collection[0].name].objects.link(col)
+            original_collection[0].objects.unlink(col)
         col.parent = obj
-        col.select_set(True)
+        col.hide_set(True)
         bpy.context.view_layer.objects.active = col
         col.muproperties.collider = 'MU_COL_MESH'
 


### PR DESCRIPTION
I repaired two issues I came across with creating mesh colliders. Some would duplicate and others would be linked but not appear in the same collection. This fixes that.

Also, I added a line to hide the mesh collider upon creation as a quality of life. If you disagree with this, it's just line 138