### PR TITLE
Adding support to export Euler rotation

### DIFF
--- a/export_mu/animation.py
+++ b/export_mu/animation.py
@@ -158,6 +158,11 @@ property_map = {
     "energy":(
         ("m_Intensity", 1/light_power, 2),
     ),
+    "rotation_euler":(
+        ("localEulerAnglesRaw.x", 1, 0),
+        ("localEulerAnglesRaw.z", 1, 0),
+        ("localEulerAnglesRaw.y", 1, 0),
+    )
 }
 
 vector_map={


### PR DESCRIPTION
Euler rotation was not supported by this addon and it was producing the following error just for future reference. The error should be removed via this pull request. Detailed info [here](https://forum.kerbalspaceprogram.com/index.php?/topic/40056-12-17-blender-283-mu-importexport-addon/&do=findComment&comment=4146883).

`Python: Traceback (most recent call last):
  File "C:\Users\ultro\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\io_object_mu-master\export_mu\operators.py", line 63, in execute
    return export_mu(self, context, **keywords)
  File "C:\Users\ultro\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\io_object_mu-master\export_mu\operators.py", line 34, in export_mu
    mu = export.export_object (context.active_object, filepath)
  File "C:\Users\ultro\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\io_object_mu-master\export_mu\export.py", line 181, in export_object
    anim_root_obj.animation = make_animations(mu, animations, anim_root)
  File "C:\Users\ultro\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\io_object_mu-master\export_mu\animation.py", line 296, in make_animations
    clip.curves.append(make_curve(mu, muobj, curve, path, typ))
  File "C:\Users\ultro\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\io_object_mu-master\export_mu\animation.py", line 172, in make_curve
    property, mult, ctyp = property_map[curve.data_path][curve.array_index]
KeyError: 'rotation_euler'`