### PR TITLE
fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -107,6 +107,7 @@ def unregister():
             menu[0].remove(menu[1])
         for cls in reversed(mod[0]):
             unregister_class(cls)
+    registered_submodules.clear()
 
 if __name__ == "__main__":
     register()

--- a/import_mu/import_mu.py
+++ b/import_mu/import_mu.py
@@ -97,9 +97,6 @@ def create_object(mu, muobj, parent):
         else:
             print(f"unhandled component {component}")
 
-    if hasattr(muobj, "bone") and not component_data and not muobj.force_import:
-        return None
-
     if hasattr(muobj, "armature_obj") or len(component_data) != 1:
         # empty or multiple components
         obj = None


### PR DESCRIPTION
first fix resets a variable while unregistering the addon (needed if you want to reload the addon later)

second fix deletes an if that prevented the correct import of .mu files like e.g. the Z1 of HabTech2